### PR TITLE
Update runtime to 20.08

### DIFF
--- a/org.wxhexeditor.wxHexEditor.json
+++ b/org.wxhexeditor.wxHexEditor.json
@@ -1,15 +1,18 @@
 {
     "app-id": "org.wxhexeditor.wxHexEditor",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "wxHexEditor",
     "rename-icon": "wxHexEditor",
     "rename-desktop-file": "wxHexEditor.desktop",
     "finish-args": [
-        "--share=ipc", "--socket=x11",
+        "--device=all",
         "--filesystem=home",
-        "--device=all"
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=x11"
     ],
     "modules": [
         {
@@ -39,8 +42,8 @@
           "sources": [ 
             {  
                 "type": "archive", 
-                "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2",
-                "sha256":"96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"
+                "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5.1/wxWidgets-3.0.5.1.tar.bz2",
+                "sha256":"440f6e73cf5afb2cbf9af10cec8da6cdd3d3998d527598a53db87099524ac807"
             }
           ]
         },


### PR DESCRIPTION
This is a quick bump of the runtime, tested briefly, and it seems to be working correctly.  
I'm not really using this app but it's installed on my system, and this is the only Flathub app on my system that's still using the 19.08 runtime.

#### Changes

* Update runtime to the latest 20.08
* Enable Wayland access and add fallback-x11. x11 socket access kept for compatibility mode with (terribly) outdated Flatpak versions. I haven't noticed any issue when running as a native Wayland client. Tested with Sway 1.5.
* Update wxWidgets to v3.0.5.1.

I really dislike having the `--device=all` permission. If the user wants to read block devices then override the default but not force it on all users without a good reason.  
Nevertheless, I'm keeping it in until I'll get feedback about it from the maintainer.